### PR TITLE
Don't assume users are in /home/

### DIFF
--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -23,7 +23,7 @@
 
 - name: Setting user's home permission
   file: >
-    dest=/home/{{ item.username }}
+    dest=~{{ item.username }}
     owner={{ item.username }}
     group={{ item.group if item.group is defined else (users_group if users_group != false else item.username) }}
     mode=0755


### PR DESCRIPTION
This changes ansible to use ~username instead of /home/username when managing
the users home directory. The change uses the value stored in /etc/passwd
instead of assuming users will be in /home.

Examples of users outside /home are root and system accounts
