### PR TITLE
Allow setting home directory mode to something other then 0755

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ authorized_keys:    (required)
 group: staff
 # list of secondary groups
 groups: ["adm", "www-data"]
+# Change permission on users home directory
+homeperms: 701
 # private key
 ssh_key: "xxx"
 ```

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -26,7 +26,7 @@
     dest=/home/{{ item.username }}
     owner={{ item.username }}
     group={{ item.group if item.group is defined else (users_group if users_group != false else item.username) }}
-    mode=0755
+    mode={{ item.homeperms |default('0755') }}
   with_items: users
   tags:
     - system


### PR DESCRIPTION
Its unusual (especially on multi user systems) to really want a home directory
thats 755 - it makes some sense to have 750 but 755 doesn't leave you much in
the way of privacy.

With this option the permissions can be changed per user with a default of 0755

I wasn't entirely convinced about the option name (homeperms) but 'mode' and 'home' both seemed a bit ambiguous.
