### PR TITLE
Fix `when` clause when adding the primary user group.

### DIFF
--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -2,7 +2,7 @@
 
 - name: Adding primary group
   group: name="{{ users_group }}" state=present
-  when: users_group is defined
+  when: users_group is defined and users_group is not none and users_group != ''
 
 - name: Adding secondary groups
   group: name="{{ item }}" state=present

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -2,7 +2,7 @@
 
 - name: Adding primary group
   group: name="{{ users_group }}" state=present
-  when: users_group is defined and users_group is not none and users_group != ''
+  when: users_group is defined and users_group
 
 - name: Adding secondary groups
   group: name="{{ item }}" state=present


### PR DESCRIPTION
If `users_group` is empty, a group called "None" got added. If `users_group` is an empty
string, you'd get an error. This fixes both of those scenarios so that they are properly
ignored.