### PR TITLE
Clarify the expected format of the password

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here is a list of all the default variables for this role, which are also availa
 #     name: Foo Bar
 #     uid: 1000
 #     group: staff
-#     password: xxxxx
+#     password: xxxxx               (A hash created with: mkpasswd)
 #     groups: ["adm", "www-data"]
 #     home_mode: "0750"
 #     home_create: yes


### PR DESCRIPTION
I think it would be a nice addition to the README that the expected format of the 'password' value is the password hash and not a plain text password.