### PR TITLE
Custom authorized keys file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ users_ssh_key_bits: 2048
 # default user's setting for authorized keys exclusive
 users_authorized_keys_exclusive: no
 # default user's setting for authorized keys path. Special marker "###USERNAME###" will be replaced with the username.
-users_authorized_keys_path:
+users_authorized_keys_path: "/home/###USERNAME###/.ssh/authorized_keys"
 # whether this module should manage the directory of the authorized keys file
 users_authorized_keys_manage_dir: yes
 # list of users to be removed

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Here is a list of all the default variables for this role, which are also availa
 #     system: no
 #     authorized_keys: []
 #     authorized_keys_exclusive: yes
+#     authorized_keys_path: ""
+#     authorized_keys_manage_dir: yes
 #     ssh_key_type: rsa
 #     ssh_key_bits: 2048
 #     ssh_key_password: ""
@@ -82,6 +84,10 @@ users_ssh_key_type: rsa
 users_ssh_key_bits: 2048
 # default user's setting for authorized keys exclusive
 users_authorized_keys_exclusive: no
+# default user's setting for authorized keys path. Special marker "###USERNAME###" will be replaced with the username.
+users_authorized_keys_path:
+# whether this module should manage the directory of the authorized keys file
+users_authorized_keys_manage_dir: yes
 # list of users to be removed
 users_remove: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ users_ssh_key_bits: 2048
 # default user's setting for authorized keys exclusive
 users_authorized_keys_exclusive: no
 # default user's setting for authorized keys path. Special marker "###USERNAME###" will be replaced with the username.
-users_authorized_keys_path:
+users_authorized_keys_path: "/home/###USERNAME###/.ssh/authorized_keys"
 # whether this module should manage the directory of the authorized keys file
 users_authorized_keys_manage_dir: yes
 # list of users to be removed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@
 #     system: no
 #     authorized_keys: []
 #     authorized_keys_exclusive: yes
+#     authorized_keys_path: ""
+#     authorized_keys_manage_dir: yes
 #     ssh_key_type: rsa
 #     ssh_key_bits: 2048
 #     ssh_key_password: ""
@@ -40,5 +42,9 @@ users_ssh_key_type: rsa
 users_ssh_key_bits: 2048
 # default user's setting for authorized keys exclusive
 users_authorized_keys_exclusive: no
+# default user's setting for authorized keys path. Special marker "###USERNAME###" will be replaced with the username.
+users_authorized_keys_path:
+# whether this module should manage the directory of the authorized keys file
+users_authorized_keys_manage_dir: yes
 # list of users to be removed
 users_remove: []

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -65,8 +65,10 @@
   authorized_key:
     key: "{{ item.authorized_keys | default([]) | join('\n') }}"
     user: "{{ item.username }}"
+    path: "{{ item.authorized_keys_path | default(users_authorized_keys_path) | regex_replace('###USERNAME###', item.username) }}"
+    manage_dir: "{{ item.authorized_keys_manage_dir | default(users_authorized_keys_manage_dir) }}"
     exclusive: "{{ item.authorized_keys_exclusive | default(users_authorized_keys_exclusive) }}"
-  when: item.home_create is not defined or item.home_create
+  when: item.home_create is not defined or item.home_create or item.authorized_keys_path or users_authorized_keys_path
   with_items: "{{ users }}"
 
 - name: Removing users

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -68,7 +68,7 @@
     path: "{{ item.authorized_keys_path | default(users_authorized_keys_path) | regex_replace('###USERNAME###', item.username) }}"
     manage_dir: "{{ item.authorized_keys_manage_dir | default(users_authorized_keys_manage_dir) }}"
     exclusive: "{{ item.authorized_keys_exclusive | default(users_authorized_keys_exclusive) }}"
-  when: item.home_create is not defined or item.home_create or item.authorized_keys_path or users_authorized_keys_path
+  when: item.home_create is not defined or item.home_create or (item.authorized_keys_path is defined and item.authorized_keys_path) or users_authorized_keys_path
   with_items: "{{ users }}"
 
 - name: Removing users


### PR DESCRIPTION
Add new variables to define a custom authorized_key `path`. Additionally, add another variable to control the `manage_dir` option.

Example usage:
```
users_authorized_keys_path: "/etc/ssh/keys/###USERNAME###"
users_authorized_keys_manage_dir: no
```