### PR TITLE
25 enhancement create default user files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Here is a list of all the default variables for this role, which are also availa
 #     ssh_key: "xxx" or "{{ lookup('file', '/path/to/id_rsa') }}"
 #     shell: /bin/bash
 #     update_password: always
+#     user_files:
+#       - '/path/to/user/home/.bashrc'
+#       - '/path/to/user/home/.bash_profile'
 #
 
 # list of users to add
@@ -128,6 +131,9 @@ This is an example playbook:
         ssh_key_password: secret
       - username: foobar_system
         system: yes
+      - username: foobar_files
+        user_files:
+         - '/path/to/user/home/.bashrc'
     users_group: staff
     users_groups:
       - www-data

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,9 @@
 #     ssh_key: "xxx" or "{{ lookup('file', '/path/to/id_rsa') }}"
 #     shell: /bin/bash
 #     update_password: always
+#     user_files:
+#       - "/path/to/user/home/.bashrc"
+#       - "/path/to/user/home/.bash_profile"
 #
 
 # list of users to add

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -69,6 +69,16 @@
   when: item.home_create is not defined or item.home_create
   with_items: "{{ users }}"
 
+- name: Adding user's files
+  copy:
+    src: "{{ item.1 }}"
+    dest: "{{ item.0.home }}/{{ item.1 | basename }}"
+    owner: "{{ item.0.username }}"
+    group: "{{ item.0.group if item.0.group is defined else (users_group if users_group else item.0.username) }}"
+  with_subelements:
+    - "{{ users }}"
+    - user_files
+
 - name: Removing users
   user:
     name: "{{ item }}"

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -29,6 +29,9 @@
         ssh_key_password: secret
       - username: foobar_system
         system: yes
+      - username: foobar_file
+        user_files:
+          - "tests/.bashrc"
     users_group: staff
     users_groups:
       - www-data


### PR DESCRIPTION
This PR adds a task & accompanying documentation for adding files to a user's home directory. It assumes any files added this way will always live at `/home/username/filename` without nested directories.

@franklinkim I'm sorry, but I have no idea how to make your tests work. I whipped up a small vagrant-ansible test to test my changes. [Download it](https://www.dropbox.com/s/hd6psdknp561ux4/ansible-users-test.tgz?dl=0), cd into it, and run Vagrant up (it'll pull down HEAD of my branch and run the playbook).

Let me know if you'd like to see any changes.