### PR TITLE
Fix directory not found in check mode

### DIFF
--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -12,76 +12,9 @@
     state: present
   with_items: "{{ users_groups | default([]) }}"
 
-- name: Adding users
-  user:
-    name: "{{ item.username }}"
-    uid: "{{ item.uid | default(omit) }}"
-    home: "{{ item.home | default(users_home ~ '/' ~ item.username ) }}"
-    comment: "{{ item.name | default(omit) }}"
-    system: "{{ item.system | default(omit) }}"
-    generate_ssh_key: "{{ item.ssh_key_generate | default(omit) }}"
-    group: "{{
-            omit if item.group is defined and item.group == item.username
-            else (item.group if item.group is defined else (users_group if users_group else omit))
-            }}"
-    groups: "{{ item.groups|join(',') if item.groups is defined else users_groups|join(',') }}"
-    append: "{{ item.append | default(omit) }}"
-    password: "{{ item.password | default(omit) }}"
-    ssh_key_file: ".ssh/id_{{ item.ssh_key_type | default(users_ssh_key_type) }}"
-    ssh_key_passphrase: "{{ item.ssh_key_password | default(omit) }}"
-    ssh_key_bits: "{{ item.ssh_key_bits | default(users_ssh_key_bits) }}"
-    createhome: "{{ item.home_create | default(omit) }}"
-    shell: "{{ item.shell | default(omit) }}"
-    update_password: "{{ item.update_password | default(omit) }}"
+- name: "Configure users"
+  include_tasks: user.yml
   with_items: "{{ users }}"
-
-- name: Setting user's home permission
-  file:
-    dest: "{{ item.home | default(users_home ~ '/' ~ item.username) }}"
-    owner: "{{ item.username }}"
-    group: "{{ item.group if item.group is defined else (users_group if users_group else item.username) }}"
-    mode: "{{ item.home_mode if item.home_mode is defined else users_home_mode }}"
-  when: item.home_create is not defined or item.home_create
-  with_items: "{{ users }}"
-
-- name: Adding user's .ssh directory
-  file:
-    path: "{{ item.home | default(users_home ~ '/' ~ item.username) }}/.ssh"
-    owner: "{{ item.username }}"
-    group: "{{ item.group if item.group is defined else (users_group if users_group else item.username) }}"
-    state: directory
-    mode: '0700'
-  when: item.home_create is not defined or item.home_create
-  with_items: "{{ users }}"
-
-- name: Adding user's private key
-  template:
-    src: home/user/ssh/private-key.j2
-    dest: "{{ item.home | default(users_home ~ '/' ~ item.username) }}/.ssh/id_{{ item.ssh_key_type | default('rsa') }}"
-    owner: "{{ item.username }}"
-    group: "{{ item.group if item.group is defined else (users_group if users_group else item.username) }}"
-    mode: '0600'
-  when: (item.home_create is not defined or item.home_create) and item.ssh_key is defined
-  with_items: "{{ users }}"
-
-- name: Adding user's authorized keys
-  authorized_key:
-    key: "{{ item.authorized_keys | default([]) | join('\n') }}"
-    user: "{{ item.username }}"
-    exclusive: "{{ item.authorized_keys_exclusive | default(users_authorized_keys_exclusive) }}"
-  when: item.home_create is not defined or item.home_create
-  with_items: "{{ users }}"
-
-- name: Adding user's home files
-  copy:
-    src: "{{ item.1 }}"
-    dest: "{{ item.0.home | default(users_home ~ '/' ~ item.0.username) }}/{{ item.1 | basename }}"
-    owner: "{{ item.0.username }}"
-    group: "{{ item.0.group if item.0.group is defined else (users_group if users_group else item.0.username) }}"
-  with_subelements:
-    - "{{ users }}"
-    - home_files
-    - skip_missing: yes
 
 - name: Removing users
   user:

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,0 +1,27 @@
+---
+
+- name: "User | Adding '{{ item.username }}' to the system"
+  user:
+    name: "{{ item.username }}"
+    uid: "{{ item.uid | default(omit) }}"
+    home: "{{ item.home | default(users_home ~ '/' ~ item.username ) }}"
+    comment: "{{ item.name | default(omit) }}"
+    system: "{{ item.system | default(omit) }}"
+    generate_ssh_key: "{{ item.ssh_key_generate | default(omit) }}"
+    group: "{{
+            omit if item.group is defined and item.group == item.username
+            else (item.group if item.group is defined else (users_group if users_group else omit))
+            }}"
+    groups: "{{ item.groups|join(',') if item.groups is defined else users_groups|join(',') }}"
+    append: "{{ item.append | default(omit) }}"
+    password: "{{ item.password | default(omit) }}"
+    ssh_key_file: ".ssh/id_{{ item.ssh_key_type | default(users_ssh_key_type) }}"
+    ssh_key_passphrase: "{{ item.ssh_key_password | default(omit) }}"
+    ssh_key_bits: "{{ item.ssh_key_bits | default(users_ssh_key_bits) }}"
+    createhome: "{{ item.home_create | default(omit) }}"
+    shell: "{{ item.shell | default(omit) }}"
+    update_password: "{{ item.update_password | default(omit) }}"
+
+- name: User | Configure home
+  include_tasks: user_home.yml
+  when: item.home_create is not defined or item.home_create

--- a/tasks/user_home.yml
+++ b/tasks/user_home.yml
@@ -1,0 +1,44 @@
+---
+
+- name: User | Setting home permission
+  file:
+    dest: "{{ item.home | default(users_home ~ '/' ~ item.username) }}"
+    owner: "{{ item.username }}"
+    group: "{{ item.group if item.group is defined else (users_group if users_group else item.username) }}"
+    mode: "{{ item.home_mode if item.home_mode is defined else users_home_mode }}"
+  when: not ansible_check_mode
+
+- name: User | Adding .ssh directory
+  file:
+    path: "{{ item.home | default(users_home ~ '/' ~ item.username) }}/.ssh"
+    owner: "{{ item.username }}"
+    group: "{{ item.group if item.group is defined else (users_group if users_group else item.username) }}"
+    state: directory
+    mode: '0700'
+
+- name: User | Adding private key
+  template:
+    src: home/user/ssh/private-key.j2
+    dest: "{{ item.home | default(users_home ~ '/' ~ item.username) }}/.ssh/id_{{ item.ssh_key_type | default('rsa') }}"
+    owner: "{{ item.username }}"
+    group: "{{ item.group if item.group is defined else (users_group if users_group else item.username) }}"
+    mode: '0600'
+  when: item.ssh_key is defined
+
+- name: User | Adding authorized keys
+  authorized_key:
+    key: "{{ item.authorized_keys | default([]) | join('\n') }}"
+    user: "{{ item.username }}"
+    exclusive: "{{ item.authorized_keys_exclusive | default(users_authorized_keys_exclusive) }}"
+  when: not ansible_check_mode
+
+- name: User | Adding home files
+  copy:
+    src: "{{ home_file }}"
+    dest: "{{ item.home | default(users_home ~ '/' ~ item.username) }}/{{ home_file | basename }}"
+    owner: "{{ item.username }}"
+    group: "{{ item.group if item.group is defined else (users_group if users_group else item.username) }}"
+  with_items: "{{ item.home_files }}"
+  loop_control:
+    loop_var: home_file
+  when: item.home_files is defined


### PR DESCRIPTION
When running the role as check-mode, new home directories won't exist, and errors will be raised when trying to change its permission.
I've also reworked the logic to iterate on each user, instead of iterating again for each task.
This also improves the performance a bit.