### PR TITLE
Add default variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,16 @@ Here is a list of all the default variables for this role, which are also availa
 users: []
 # users home directory
 users_home: /home
+# create user's home directory
+users_home_create: yes
 # default user's primary group for users
 users_group:
 # default user's secondary groups
 users_groups: []
 # default user's home directory permissions
 users_home_mode: "0755"
+# default user login shell
+#users_shell:
 # default user's ssh key type
 users_ssh_key_type: rsa
 # default user's ssh key bits

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Here is a list of all the default variables for this role, which are also availa
 
 # list of users to add
 users: []
+# default user's dotfiles
+users_home_files: []
 # users home directory
 users_home: /home
 # create user's home directory

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,12 +35,16 @@
 users: []
 # users home directory
 users_home: /home
+# create user's home directory
+users_home_create: yes
 # default user's primary group for users
 users_group:
 # default user's secondary groups
 users_groups: []
 # default user's home directory permissions
 users_home_mode: "0755"
+# default user login shell
+#users_shell:
 # default user's ssh key type
 users_ssh_key_type: rsa
 # default user's ssh key bits

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,8 @@
 
 # list of users to add
 users: []
+# default user's dotfiles
+users_home_files: []
 # users home directory
 users_home: /home
 # create user's home directory

--- a/tasks/manage_user.yml
+++ b/tasks/manage_user.yml
@@ -18,10 +18,10 @@
     ssh_key_file: ".ssh/id_{{ item.ssh_key_type | default(users_ssh_key_type) }}"
     ssh_key_passphrase: "{{ item.ssh_key_password | default(omit) }}"
     ssh_key_bits: "{{ item.ssh_key_bits | default(users_ssh_key_bits) }}"
-    createhome: "{{ item.home_create | default(omit) }}"
-    shell: "{{ item.shell | default(omit) }}"
+    createhome: "{{ item.home_create | default(users_home_create) }}"
+    shell: "{{ item.shell | default(users_shell | default(omit)) }}"
     update_password: "{{ item.update_password | default(omit) }}"
 
 - name: Configuring user's home
   import_tasks: manage_user_home.yml
-  when: item.home_create is not defined or item.home_create
+  when: item.home_create | default(users_home_create)

--- a/tasks/manage_user_home.yml
+++ b/tasks/manage_user_home.yml
@@ -17,8 +17,8 @@
     mode: '0700'
 
 - name: Adding user's private key
-  template:
-    src: home/user/ssh/private-key.j2
+  copy:
+    content: "{{ item.ssh_key }}"
     dest: "{{ item.home | default(users_home ~ '/' ~ item.username) }}/.ssh/id_{{ item.ssh_key_type | default('rsa') }}"
     owner: "{{ item.username }}"
     group: "{{ item.group if item.group is defined else (users_group if users_group else item.username) }}"

--- a/tasks/manage_user_home.yml
+++ b/tasks/manage_user_home.yml
@@ -38,7 +38,6 @@
     dest: "{{ item.home | default(users_home ~ '/' ~ item.username) }}/{{ home_file | basename }}"
     owner: "{{ item.username }}"
     group: "{{ item.group if item.group is defined else (users_group if users_group else item.username) }}"
-  with_items: "{{ item.home_files }}"
+  with_items: "{{ item.home_files | default(users_home_files) }}"
   loop_control:
     loop_var: home_file
-  when: item.home_files is defined

--- a/templates/home/user/ssh/private-key.j2
+++ b/templates/home/user/ssh/private-key.j2
@@ -1,1 +1,0 @@
-{{ item.ssh_key | default('') }}


### PR DESCRIPTION
Having default variables for the login shell and for createhome is useful when we have lots of users sharing the same configuration.

The private-key template file isn't needed, the task content field is enough.