### PR TITLE
Prevents logging of private keys during playbook run

### DIFF
--- a/tasks/manage_user_home.yml
+++ b/tasks/manage_user_home.yml
@@ -24,6 +24,7 @@
     group: "{{ user.group if user.group is defined else (users_group if users_group else user.username) }}"
     mode: '0600'
   when: user.ssh_key is defined
+  no_log: true
 
 - name: Adding user's private keys
   copy:


### PR DESCRIPTION
- Adds `no_log: true` to `Adding user's private key` task.
- Re: gh-41

---

This prevents the contents of the file being echoed out into the `ansible-playbook` output, but it can also impede debugging. 

If we think this is a problem, we can change `no_log: true` to something like `no_log: "{{ users_enable_unsafe_debugging | ternary(false, true) }}"` along with a corresponding variable set to `false`.