### PR TITLE
Adds no_log to _second_ ssh key transfer task

### DIFF
--- a/tasks/manage_user_home.yml
+++ b/tasks/manage_user_home.yml
@@ -35,6 +35,7 @@
     mode: '0600'
   when: user.ssh_key is not defined and user.ssh_keys is defined
   with_dict: "{{ user.ssh_keys }}"
+  no_log: true
 
 - name: Adding user's authorized keys
   authorized_key:


### PR DESCRIPTION
- Missed this task on the first PR (oops!)
- Re: gh-41

---

I didn't read the tasks carefully enough to notice that there were _two_ ssh key transfers. Sorry for duplication.