### PR TITLE
Feat: manage sudoers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Here is a list of all the default variables for this role, which are also availa
 #       id_rsa_2: "xxx" or "{{ lookup('file', '/path/to/id_rsa') }}"
 #     shell: /bin/bash
 #     update_password: always
+#     sudoer: yes
+#     sudo_ask_passwd: yes          (defaults to no, eq. 'NOPASSWD')
 #
 
 # list of users to add
@@ -104,6 +106,8 @@ users_ssh_key_bits: 2048
 users_authorized_keys_exclusive: no
 # list of users to be removed
 users_remove: []
+# default user's sudo privileges
+users_become_sudoer: no
 
 ```
 
@@ -152,6 +156,19 @@ This is an example playbook:
       - username: foobar_file
         home_files:
           - "tests/.bashrc"
+      - username: bar_sudo
+        password: $6$pBtCEpYB$6vc5Dhwf.YI6jCUyJRBmgacB4qri2Y1WmINjufblB97sZpuhhEkUvZhTB8rGUKRq.urifltBSSh68rh.esHCS.
+        home: /home/bar_sudo
+        shell: /bin/bash
+        update_password: always
+        sudoer: yes
+      - username: foo_sudo
+        password: $6$bhdpgAcPxL$rNcZtYZj2sAuDD.dNsdT98zEp9zO7Mwt1wjLjYb47hKew062X3Vau3BukY8cRVNtwixqScJMECMu8p3YQDhpf0
+        home: /home/foo_sudo
+        shell: /bin/bash
+        update_password: always
+        sudoer: yes
+        sudo_ask_passwd: yes
     users_group: staff
     users_groups:
       - www-data

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,3 +58,5 @@ users_ssh_key_bits: 2048
 users_authorized_keys_exclusive: no
 # list of users to be removed
 users_remove: []
+# default user's sudo privileges
+users_become_sudoer: no

--- a/tasks/manage_sudoers.yml
+++ b/tasks/manage_sudoers.yml
@@ -1,0 +1,22 @@
+---
+- name: Ensure sudo package is present
+  block:
+    - apt:
+        name: sudo
+        state: present
+      when: ansible_os_family == 'Debian'
+    - yum:
+        name: sudo
+        state: present
+      when: ansible_os_family == 'CentOS'
+
+- name: Register user to the sudoers
+  copy:
+    content: |
+      {{ user.username }}  ALL=(ALL)  {{
+        'NOPASSWD' if user.sudo_ask_passwd is not defined
+        else user.sudo_ask_passwd | ternary('PASSWD', 'NOPASSWD')
+      }}: ALL
+
+    dest: "/etc/sudoers.d/{{ user.username }}"
+    validate: /usr/sbin/visudo -csf %s

--- a/tasks/manage_user.yml
+++ b/tasks/manage_user.yml
@@ -24,4 +24,8 @@
 
 - name: Configuring user's home
   import_tasks: manage_user_home.yml
-  when: user.home_create | default(users_home_create)
+  when: user.home_create | default(users_home_create) | bool
+
+- name: Manage user's sudo privileges
+  import_tasks: manage_sudoers.yml
+  when: user.sudoer | default(users_become_sudoer) | bool

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -37,6 +37,19 @@
       - username: foobar_file
         home_files:
           - "tests/.bashrc"
+      - username: bar_sudo
+        password: $6$pBtCEpYB$6vc5Dhwf.YI6jCUyJRBmgacB4qri2Y1WmINjufblB97sZpuhhEkUvZhTB8rGUKRq.urifltBSSh68rh.esHCS.
+        home: /home/bar_sudo
+        shell: /bin/bash
+        update_password: always
+        sudoer: yes
+      - username: foo_sudo
+        password: $6$bhdpgAcPxL$rNcZtYZj2sAuDD.dNsdT98zEp9zO7Mwt1wjLjYb47hKew062X3Vau3BukY8cRVNtwixqScJMECMu8p3YQDhpf0
+        home: /home/foo_sudo
+        shell: /bin/bash
+        update_password: always
+        sudoer: yes
+        sudo_ask_passwd: yes
     users_group: staff
     users_groups:
       - www-data


### PR DESCRIPTION
Greetings,

This is again a feature proposal initially motivated by personal needs : defining user's privileges along with their creation. This feature allows to create sudoers with and without password prompts.

EDIT : I've later noticed you had this [ansible-sudo](https://github.com/weareinteractive/ansible-sudo) role so I believe this PR, while functional, does not match some requirements some people could satisfy using it instead.
Closing.