### PR TITLE
Add support to enable/disable user creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ This is an example playbook:
       - username: foobar_file
         home_files:
           - "tests/.bashrc"
+      - username: root
+        user_create: no
+        home_create: no
     users_group: staff
     users_groups:
       - www-data

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,3 +61,5 @@ users_ssh_key_bits: 2048
 users_authorized_keys_exclusive: no
 # list of users to be removed
 users_remove: []
+# create users, can be overridden with user_create on a per user base
+users_user_create: yes

--- a/tasks/manage_user.yml
+++ b/tasks/manage_user.yml
@@ -21,6 +21,7 @@
     createhome: "{{ user.home_create | default(users_home_create) }}"
     shell: "{{ user.shell | default(users_shell | default(omit)) }}"
     update_password: "{{ user.update_password | default(omit) }}"
+  when: user.user_create | default(users_user_create)
 
 - name: Configuring user's home
   import_tasks: manage_user_home.yml


### PR DESCRIPTION
As stated in https://github.com/weareinteractive/ansible-users/issues/46 the role fails when the **root**-user is included in the **users: array**, since this user may be in use by the **ansible_user**:
```
weareinteractive.users : Adding user 'root' to the system
usermod: user root is currently used by process 1
```
However, it does make sense having the root user in the **users: array** sine other roles may pick it up from there to configure per user tasks.
This is true for **gantsign.antigen** for example that manages the setup of **oh-my-zsh** and related plugins.

I added a variable **user_create** to the **users: array** which is queried by a **when filter** for the **Adding user** task.
The default can be set with the globally scoped var **users_user_create**.

I have also added an example case to the `README.md` file.