### PR TITLE
Adding gid to user_group and user_groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,12 @@ This is an example playbook:
       - username: foobar_file
         home_files:
           - "tests/.bashrc"
-    users_group: staff
+    users_group:
+      name: staff
+      gid: 50
     users_groups:
-      - www-data
+      - name: www-data
+        gid: 33
     users_authorized_keys_exclusive: yes
     users_remove:
     - foobar

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -2,13 +2,15 @@
 
 - name: Adding primary group
   ansible.builtin.group:
-    name: "{{ users_group }}"
+    name: "{{ users_group.name }}"
+    gid: "{{ users_group.gid | default(omit) }}"
     state: present
-  when: users_group is defined and users_group
+  when: users_group is defined and users_group.name is defined
 
 - name: Adding secondary groups
   ansible.builtin.group:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
+    gid: "{{ item.gid | default(omit) }}"
     state: present
   with_items: "{{ users_groups | default([]) }}"
 

--- a/tasks/manage_user.yml
+++ b/tasks/manage_user.yml
@@ -10,9 +10,9 @@
     generate_ssh_key: "{{ user.ssh_key_generate | default(omit) }}"
     group: "{{
             omit if user.group is defined and user.group == user.username
-            else (user.group if user.group is defined else (users_group if users_group else omit))
+            else (user.group if user.group is defined else (users_group.name if users_group else omit))
             }}"
-    groups: "{{ user.groups|join(',') if user.groups is defined else users_groups|join(',') }}"
+    groups: "{{ user.groups if user.groups is defined else users_groups | map(attribute='name') | list }}"
     append: "{{ user.append | default(omit) }}"
     password: "{{ user.password | default(omit) }}"
     ssh_key_file: ".ssh/id_{{ user.ssh_key_type | default(users_ssh_key_type) }}"

--- a/tasks/manage_user_home.yml
+++ b/tasks/manage_user_home.yml
@@ -4,7 +4,7 @@
   file:
     dest: "{{ user.home | default(users_home ~ '/' ~ user.username) }}"
     owner: "{{ user.username }}"
-    group: "{{ user.group if user.group is defined else (users_group if users_group else user.username) }}"
+    group: "{{ user.group if user.group is defined else (users_group.name if users_group else user.username) }}"
     mode: "{{ user.home_mode if user.home_mode is defined else users_home_mode }}"
   ignore_errors: "{{ ansible_check_mode }}"
 
@@ -12,7 +12,7 @@
   file:
     path: "{{ user.home | default(users_home ~ '/' ~ user.username) }}/.ssh"
     owner: "{{ user.username }}"
-    group: "{{ user.group if user.group is defined else (users_group if users_group else user.username) }}"
+    group: "{{ user.group if user.group is defined else (users_group.name if users_group else user.username) }}"
     state: directory
     mode: 0700
 
@@ -21,7 +21,7 @@
     content: "{{ user.ssh_key }}"
     dest: "{{ user.home | default(users_home ~ '/' ~ user.username) }}/.ssh/id_{{ user.ssh_key_type | default('rsa') }}"
     owner: "{{ user.username }}"
-    group: "{{ user.group if user.group is defined else (users_group if users_group else user.username) }}"
+    group: "{{ user.group if user.group is defined else (users_group.name if users_group else user.username) }}"
     mode: 0600
   when: user.ssh_key is defined
   no_log: true
@@ -31,7 +31,7 @@
     content: "{{ item.value }}"
     dest: "{{ user.home | default(users_home ~ '/' ~ user.username) }}/.ssh/{{ item.key }}"
     owner: "{{ user.username }}"
-    group: "{{ user.group if user.group is defined else (users_group if users_group else user.username) }}"
+    group: "{{ user.group if user.group is defined else (users_group.name if users_group else user.username) }}"
     mode: 0600
   when: user.ssh_key is not defined and user.ssh_keys is defined
   with_dict: "{{ user.ssh_keys }}"
@@ -48,7 +48,7 @@
     src: "{{ home_file }}"
     dest: "{{ user.home | default(users_home ~ '/' ~ user.username) }}/{{ home_file | basename }}"
     owner: "{{ user.username }}"
-    group: "{{ user.group if user.group is defined else (users_group if users_group else user.username) }}"
+    group: "{{ user.group if user.group is defined else (users_group.name if users_group else user.username) }}"
   with_items: "{{ user.home_files | default(users_home_files) }}"
   loop_control:
     loop_var: home_file

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -43,9 +43,10 @@
       - username: foobar_file
         home_files:
           - "tests/.bashrc"
-    users_group: staff
+    users_group:
+      name: staff
     users_groups:
-      - www-data
+      - name: www-data
     users_authorized_keys_exclusive: yes
     users_remove:
     - foobar


### PR DESCRIPTION
Converted `user_group` and `users_group` parameters to objectives, supporting `name` and optional `gid` properties. This is a **breaking change**. It should be possible to detect string or object and convert to avoid this being a breaking change, however I wanted to check the appetite on merging this before doing more work. 